### PR TITLE
Change $(pwd) to absolute path

### DIFF
--- a/wlinux-setup
+++ b/wlinux-setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SetupDir=${pwd}
+SetupDir="/etc/wlinux-setup.d"
 VERSION="1.2a"
 
 # define functions


### PR DESCRIPTION
Using ${pwd} for SetupDir gives "____.sh not found" as it is grabbing the calling directory, not the directory of the scripts themselves. An absolute path fixes this.

Signed-off-by: Kim Bradley <kim.jamie.bradley@gmail.com>