### PR TITLE
 Fix missing rbenv depdencies #269

### DIFF
--- a/wlinux-setup.d/ruby.sh
+++ b/wlinux-setup.d/ruby.sh
@@ -5,7 +5,9 @@ source "/etc/wlinux-setup.d/common.sh"
 if (whiptail --title "RUBY" --yesno "Would you like to download and install Ruby using rbenv?" 8 65) then
     echo "Installing RUBY"
     echo "Installing Ruby dependencies"
-    sudo apt -t testing install git-core curl zlib1g-dev build-essential libssl-dev libssl1.0-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev -y
+
+    updateupgrade
+    sudo apt -t testing install git-core curl zlib1g-dev build-essential libssl-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev -y
     createtmp
 
     echo "Getting rbenv"

--- a/wlinux-setup.d/ruby.sh
+++ b/wlinux-setup.d/ruby.sh
@@ -2,31 +2,34 @@
 
 source "/etc/wlinux-setup.d/common.sh"
 
-if (whiptail --title "RUBY" --yesno "Would you like to download and install Ruby using rbenv?" 8 65) then
+if (whiptail --title "RUBY" --yesno "Would you like to download and install Ruby using rbenv?" 8 65); then
     echo "Installing RUBY"
     echo "Installing Ruby dependencies"
 
     updateupgrade
-    sudo apt -t testing install git-core curl zlib1g-dev build-essential libssl-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev -y
+    sudo apt-get -y -t testing install git-core curl zlib1g-dev build-essential libssl-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev
     createtmp
 
     echo "Getting rbenv"
     git clone https://github.com/rbenv/rbenv.git ~/.rbenv
 
     echo "Configuring rbenv"
-    export PATH="$HOME/.rbenv/bin:$PATH"
-    eval "$(rbenv init -)"
-    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-    echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-    source ~/.bashrc
+
+    conf_path='/etc/profile.d/ruby'
+
+    echo 'export PATH="${HOME}/.rbenv/bin:${PATH}"' | sudo tee "${conf_path}"
+    echo 'eval "$(rbenv init -)"' | sudo tee -a "${conf_path}"
 
     echo "Getting ruby-build"
     git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 
     echo "Configuring ruby-build"
-    export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"
-    echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
-    source ~/.bashrc
+    echo 'export PATH="${HOME}/.rbenv/plugins/ruby-build/bin:${PATH}"' | sudo tee -a "${conf_path}"
+    source "${conf_path}"
+
+    #Copy configuration to  fish
+    sudo mkdir -p "${__fish_sysconf_dir:=/etc/fish/conf.d}"
+    sudo cp "${conf_path}" "${__fish_sysconf_dir}"
 
     echo "Installing Ruby using rbenv"
     rbenv install 2.5.3 --verbose
@@ -34,7 +37,7 @@ if (whiptail --title "RUBY" --yesno "Would you like to download and install Ruby
     echo "Checking ruby version"
     ruby -v
     echo "Installing bundler using gem"
-    gem install bundler
+    gem install bundler -v 1.17.3
     echo "Rehashing rbenv"
     rbenv rehash
     cleantmp
@@ -42,12 +45,12 @@ else
     echo "Skipping RUBY"
 fi
 
-if (whiptail --title "RAILS" --yesno "Would you like to download and install Rails from RubyGems?" 8 65) then
+if (whiptail --title "RAILS" --yesno "Would you like to download and install Rails from RubyGems?" 8 65); then
     echo "Installing RAILS"
+    bash "nodejs.sh" "$@"
     updateupgrade
-    sudo apt -t testing install git-core curl zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev
+    sudo apt-get -y -t testing install git-core curl zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev
     createtmp
-    nodeinstall
     gem install rails -v 5.2.0
     rbenv rehash
     cleantmp


### PR DESCRIPTION
This should fix the main problem with dependences. The problem with fish is more complicated due to` eval "$(rbenv init -)"` doesn't run well in fish.

Please check it a lot, I am not a ruby user and also I didn't do this part of the setup.

I also made minor fixes specially with bundler because the last version doesn't work with the downloaded version of Ruby