### PR TITLE
Install menu fix

### DIFF
--- a/wlinux-setup
+++ b/wlinux-setup
@@ -70,91 +70,93 @@ ExitStatus=$?
 echo "Selected:" $MenuChoice
 echo "ExitStatus:" $ExitStatus
 
-if [[ $ExitStatus == 0 ]] ; then
-	if [[ ! $MenuChoice ]] ; then
-	  echo "None selected"
-	  if (whiptail --title "None Selected" --yesno "No item selected. Would you like to return to the install menu?" 10 80) then
-	  	InstallMenu
-	  else
-	  	return
-	  fi
-	fi
-	
-	if [[ $MenuChoice == *"LANGUAGE"* ]] ; then
-	  echo "LANGUAGE"
-	  bash ${SetupDir}/language.sh
-	fi
+if [[ $ExitStatus != 0 ]] ; then
+  return
+fi
 
-	if [[ $MenuChoice == *"EXPLORER"* ]] ; then
-	  echo "EXPLORER"
-	  bash ${SetupDir}/explorer.sh
-	fi
+if [[ ! $MenuChoice ]] ; then
+  echo "None selected"
+  if (whiptail --title "None Selected" --yesno "No item selected. Would you like to return to the install menu?" 10 80) then
+  	InstallMenu
+  else
+  	return
+  fi
+fi
 
-	if [[ $MenuChoice == *"SHELLS"* ]] ; then
-	  echo "SHELLS"
-	  bash ${SetupDir}/shells.sh
-	fi
+if [[ $MenuChoice == *"LANGUAGE"* ]] ; then
+  echo "LANGUAGE"
+  bash ${SetupDir}/language.sh
+fi
 
-	if [[ $MenuChoice == *"EDITORS"* ]] ; then
-	  echo "EDITORS"
-	  bash ${SetupDir}/editors.sh
-	fi 
+if [[ $MenuChoice == *"EXPLORER"* ]] ; then
+  echo "EXPLORER"
+  bash ${SetupDir}/explorer.sh
+fi
 
-	if [[ $MenuChoice == *"PYTHON"* ]] ; then
-	  echo "PYTHON"
-	  bash ${SetupDir}/python.sh
-	fi
+if [[ $MenuChoice == *"SHELLS"* ]] ; then
+  echo "SHELLS"
+  bash ${SetupDir}/shells.sh
+fi
 
-	if [[ $MenuChoice == *"NODE"* ]] ; then
-	  echo "NODE"
-	  bash ${SetupDir}/nodejs.sh
-	fi
+if [[ $MenuChoice == *"EDITORS"* ]] ; then
+  echo "EDITORS"
+  bash ${SetupDir}/editors.sh
+fi 
 
-	if [[ $MenuChoice == *"GO"* ]] ; then
-	  echo "GO"
-	  bash ${SetupDir}/go.sh
-	fi
+if [[ $MenuChoice == *"PYTHON"* ]] ; then
+  echo "PYTHON"
+  bash ${SetupDir}/python.sh
+fi
 
-	if [[ $MenuChoice == *"RUBY"* ]] ; then
-	  echo "RUBY"
-	  bash ${SetupDir}/ruby.sh
-	fi
+if [[ $MenuChoice == *"NODE"* ]] ; then
+  echo "NODE"
+  bash ${SetupDir}/nodejs.sh
+fi
 
-	if [[ $MenuChoice == *"RUST"* ]] ; then
-	  echo "RUST"
-	  bash ${SetupDir}/rust.sh
-	fi
+if [[ $MenuChoice == *"GO"* ]] ; then
+  echo "GO"
+  bash ${SetupDir}/go.sh
+fi
 
-	if [[ $MenuChoice == *"DOTNET"* ]] ; then
-	  echo "DOTNET"
-	  bash ${SetupDir}/dotnet.sh
-	fi
+if [[ $MenuChoice == *"RUBY"* ]] ; then
+  echo "RUBY"
+  bash ${SetupDir}/ruby.sh
+fi
 
-	if [[ $MenuChoice == *"JAVA"* ]] ; then
-	  echo "JAVA"
-	  bash ${SetupDir}/java.sh
-	fi
+if [[ $MenuChoice == *"RUST"* ]] ; then
+  echo "RUST"
+  bash ${SetupDir}/rust.sh
+fi
 
-	if [[ $MenuChoice == *"POWERSHELL"* ]] ; then
-	  echo "POWERSHELL"
-	  bash ${SetupDir}/powershell.sh
-	  bash ${SetupDir}/axurecli.sh
-	fi
+if [[ $MenuChoice == *"DOTNET"* ]] ; then
+  echo "DOTNET"
+  bash ${SetupDir}/dotnet.sh
+fi
 
-	if [[ $MenuChoice == *"GUI"* ]] ; then
-	  echo "GUI"
-	  bash ${SetupDir}/gui.sh
-	fi
+if [[ $MenuChoice == *"JAVA"* ]] ; then
+  echo "JAVA"
+  bash ${SetupDir}/java.sh
+fi
 
-	if [[ $MenuChoice == *"DOCKER"* ]] ; then
-	  echo "DOCKER"
-	  bash ${SetupDir}/docker.sh
-	fi
+if [[ $MenuChoice == *"POWERSHELL"* ]] ; then
+  echo "POWERSHELL"
+  bash ${SetupDir}/powershell.sh
+  bash ${SetupDir}/axurecli.sh
+fi
 
-	if [[ $MenuChoice == *"CASSANDRA"* ]] ; then
-	  echo "CASSANDRA"
-	  bash ${SetupDir}/cassandra.sh
-	fi
+if [[ $MenuChoice == *"GUI"* ]] ; then
+  echo "GUI"
+  bash ${SetupDir}/gui.sh
+fi
+
+if [[ $MenuChoice == *"DOCKER"* ]] ; then
+  echo "DOCKER"
+  bash ${SetupDir}/docker.sh
+fi
+
+if [[ $MenuChoice == *"CASSANDRA"* ]] ; then
+  echo "CASSANDRA"
+  bash ${SetupDir}/cassandra.sh
 fi
 }
 

--- a/wlinux-setup
+++ b/wlinux-setup
@@ -71,6 +71,15 @@ echo "Selected:" $MenuChoice
 echo "ExitStatus:" $ExitStatus
 
 if [[ $ExitStatus == 0 ]] ; then
+	if [[ $MenuChoice == *""* ]] ; then
+	  echo "None selected"
+	  if (whiptail --title "None Selected" --yesno "No item selected. Would you like to return to the install menu?" 10 80) then
+	  	InstallMenu
+	  else
+	  	return
+	  fi
+	fi
+	
 	if [[ $MenuChoice == *"LANGUAGE"* ]] ; then
 	  echo "LANGUAGE"
 	  bash ${SetupDir}/language.sh
@@ -145,15 +154,6 @@ if [[ $ExitStatus == 0 ]] ; then
 	if [[ $MenuChoice == *"CASSANDRA"* ]] ; then
 	  echo "CASSANDRA"
 	  bash ${SetupDir}/cassandra.sh
-	fi
-
-	if [[ $MenuChoice == *""* ]] ; then
-	  echo "None selected"
-	  if (whiptail --title "None Selected" --yesno "No item selected. Would you like to return to the install menu?" 10 80) then
-	  	InstallMenu
-	  else
-	  	return
-	  fi
 	fi
 fi
 }

--- a/wlinux-setup
+++ b/wlinux-setup
@@ -67,88 +67,101 @@ whiptail --title "wlinux-setup" --checklist --separate-output "\nHand-curated ad
     "NONE" "" on 3>&1 1>&2 2>&3
 )
 
+ExitStatus=$?
 echo "Selected:" $MenuChoice
+echo "ExitStatus:" $ExitStatus
 
-if [[ $MenuChoice == *"LANGUAGE"* ]] ; then
-  echo "LANGUAGE"
-  bash ${SetupDir}/language.sh
-fi
+if [[ $ExitStatus == 0 ]] ; then
+	if [[ $MenuChoice == *""* ]] ; then
+	  echo "None selected"
+	  whiptail --title "No selection" --msgbox "Please select your desired options using the SPACE bar and then hit ENTER to confirm." 8 80
+	  InstallMenu
+	fi
 
-if [[ $MenuChoice == *"EXPLORER"* ]] ; then
-  echo "EXPLORER"
-  bash ${SetupDir}/explorer.sh
-fi
+	if [[ $MenuChoice == *"LANGUAGE"* ]] ; then
+	  echo "LANGUAGE"
+	  bash ${SetupDir}/language.sh
+	fi
 
-if [[ $MenuChoice == *"SHELLS"* ]] ; then
-  echo "SHELLS"
-  bash ${SetupDir}/shells.sh
-fi
+	if [[ $MenuChoice == *"EXPLORER"* ]] ; then
+	  echo "EXPLORER"
+	  bash ${SetupDir}/explorer.sh
+	fi
 
-if [[ $MenuChoice == *"EDITORS"* ]] ; then
-  echo "EDITORS"
-  bash ${SetupDir}/editors.sh
-fi 
+	if [[ $MenuChoice == *"SHELLS"* ]] ; then
+	  echo "SHELLS"
+	  bash ${SetupDir}/shells.sh
+	fi
 
-if [[ $MenuChoice == *"PYTHON"* ]] ; then
-  echo "PYTHON"
-  bash ${SetupDir}/python.sh
-fi
+	if [[ $MenuChoice == *"EDITORS"* ]] ; then
+	  echo "EDITORS"
+	  bash ${SetupDir}/editors.sh
+	fi 
 
-if [[ $MenuChoice == *"NODE"* ]] ; then
-  echo "NODE"
-  bash ${SetupDir}/nodejs.sh
-fi
+	if [[ $MenuChoice == *"PYTHON"* ]] ; then
+	  echo "PYTHON"
+	  bash ${SetupDir}/python.sh
+	fi
 
-if [[ $MenuChoice == *"GO"* ]] ; then
-  echo "GO"
-  bash ${SetupDir}/go.sh
-fi
+	if [[ $MenuChoice == *"NODE"* ]] ; then
+	  echo "NODE"
+	  bash ${SetupDir}/nodejs.sh
+	fi
 
-if [[ $MenuChoice == *"RUBY"* ]] ; then
-  echo "RUBY"
-  bash ${SetupDir}/ruby.sh
-fi
+	if [[ $MenuChoice == *"GO"* ]] ; then
+	  echo "GO"
+	  bash ${SetupDir}/go.sh
+	fi
 
-if [[ $MenuChoice == *"RUST"* ]] ; then
-  echo "RUST"
-  bash ${SetupDir}/rust.sh
-fi
+	if [[ $MenuChoice == *"RUBY"* ]] ; then
+	  echo "RUBY"
+	  bash ${SetupDir}/ruby.sh
+	fi
 
-if [[ $MenuChoice == *"DOTNET"* ]] ; then
-  echo "DOTNET"
-  bash ${SetupDir}/dotnet.sh
-fi
+	if [[ $MenuChoice == *"RUST"* ]] ; then
+	  echo "RUST"
+	  bash ${SetupDir}/rust.sh
+	fi
 
-if [[ $MenuChoice == *"JAVA"* ]] ; then
-  echo "JAVA"
-  bash ${SetupDir}/java.sh
-fi
+	if [[ $MenuChoice == *"DOTNET"* ]] ; then
+	  echo "DOTNET"
+	  bash ${SetupDir}/dotnet.sh
+	fi
 
-if [[ $MenuChoice == *"POWERSHELL"* ]] ; then
-  echo "POWERSHELL"
-  bash ${SetupDir}/powershell.sh
-  bash ${SetupDir}/axurecli.sh
-fi
+	if [[ $MenuChoice == *"JAVA"* ]] ; then
+	  echo "JAVA"
+	  bash ${SetupDir}/java.sh
+	fi
 
-if [[ $MenuChoice == *"GUI"* ]] ; then
-  echo "GUI"
-  bash ${SetupDir}/gui.sh
-fi
+	if [[ $MenuChoice == *"POWERSHELL"* ]] ; then
+	  echo "POWERSHELL"
+	  bash ${SetupDir}/powershell.sh
+	  bash ${SetupDir}/axurecli.sh
+	fi
 
-if [[ $MenuChoice == *"DOCKER"* ]] ; then
-  echo "DOCKER"
-  bash ${SetupDir}/docker.sh
-fi
+	if [[ $MenuChoice == *"GUI"* ]] ; then
+	  echo "GUI"
+	  bash ${SetupDir}/gui.sh
+	fi
 
-if [[ $MenuChoice == *"CASSANDRA"* ]] ; then
-  echo "CASSANDRA"
-  bash ${SetupDir}/cassandra.sh
-fi
+	if [[ $MenuChoice == *"DOCKER"* ]] ; then
+	  echo "DOCKER"
+	  bash ${SetupDir}/docker.sh
+	fi
 
-if [[ $MenuChoice == "NONE" ]] ; then
-  echo "NONE"
-  whiptail --title "No selection" --msgbox "Please select your desired options using the SPACE bar and then hit ENTER to confirm." 8 80
-  installmenu
+	if [[ $MenuChoice == *"CASSANDRA"* ]] ; then
+	  echo "CASSANDRA"
+	  bash ${SetupDir}/cassandra.sh
+	fi
+
+	if [[ $MenuChoice == *""* ]] ; then
+	  echo "None selected"
+	  if (whiptail --title "None Selected" --yesno "No item selected. Would you like to return to the install menu?" 10 80) then
+	  	InstallMenu
+	  else
+	  	return
+	  fi
+	fi
 fi
 }
 

--- a/wlinux-setup
+++ b/wlinux-setup
@@ -71,12 +71,6 @@ echo "Selected:" $MenuChoice
 echo "ExitStatus:" $ExitStatus
 
 if [[ $ExitStatus == 0 ]] ; then
-	if [[ $MenuChoice == *""* ]] ; then
-	  echo "None selected"
-	  whiptail --title "No selection" --msgbox "Please select your desired options using the SPACE bar and then hit ENTER to confirm." 8 80
-	  InstallMenu
-	fi
-
 	if [[ $MenuChoice == *"LANGUAGE"* ]] ; then
 	  echo "LANGUAGE"
 	  bash ${SetupDir}/language.sh

--- a/wlinux-setup
+++ b/wlinux-setup
@@ -71,7 +71,7 @@ echo "Selected:" $MenuChoice
 echo "ExitStatus:" $ExitStatus
 
 if [[ $ExitStatus == 0 ]] ; then
-	if [[ $MenuChoice == *""* ]] ; then
+	if [[ ! $MenuChoice ]] ; then
 	  echo "None selected"
 	  if (whiptail --title "None Selected" --yesno "No item selected. Would you like to return to the install menu?" 10 80) then
 	  	InstallMenu

--- a/wlinux-setup
+++ b/wlinux-setup
@@ -63,8 +63,7 @@ whiptail --title "wlinux-setup" --checklist --separate-output "\nHand-curated ad
     "POWERSHELL" "Install PowerShell for Linux and/or Azure CLI tools" off \
     "GUI" "Install the basics needed for most GUI apps and configure GUI options" off \
     "DOCKER" "Install a secure bridge to Docker for Windows" off \
-    "CASSANDRA" "Install the NoSQL server Cassandra from Apache" off \
-    "NONE" "" on 3>&1 1>&2 2>&3
+    "CASSANDRA" "Install the NoSQL server Cassandra from Apache" off 3>&1 1>&2 2>&3
 )
 
 ExitStatus=$?


### PR DESCRIPTION
Removes the 'none' option from the install menu, and instead adds code to check for no option selected (prompting the user to ask if they'd like to return to the install menu), whilst keeping function of the cancel button.