### PR TITLE
Move setupscripts

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,3 @@
-wlinux-setup usr/local/bin
-wlinux-setup.d usr/local/bin
-wlinux-setup.d/* /usr/local/bin/wlinux-setup.d/*
+wlinux-setup /usr/local/bin
+wlinux-setup.d /usr/local
+wlinux-setup.d/* /usr/local/wlinux-setup.d/*

--- a/wlinux-setup
+++ b/wlinux-setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SetupDir="/etc/wlinux-setup.d"
+SetupDir="/usr/local/wlinux-setup.d"
 VERSION="1.2a"
 
 source ${SetupDir}/common.sh "$@"

--- a/wlinux-setup.d/azurecli.sh
+++ b/wlinux-setup.d/azurecli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "AZURECLI" --yesno "Would you like to download and install Azure command line tools?" 8 70) then
     echo "Installing AZURECLI"

--- a/wlinux-setup.d/cassandra.sh
+++ b/wlinux-setup.d/cassandra.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "CASSANDRA" --yesno "Would you like to download and install Apache Cassandra?" 8 60) then
     echo "Installing CASSANDRA"

--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -2,7 +2,7 @@
 
 wHomeWinPath=$(cmd.exe /c 'echo %HOMEDRIVE%%HOMEPATH%' 2>&1 | tr -d '\r')
 wHome=$(wslpath -u "${wHomeWinPath}")
-SetupDir="/etc/wlinux-setup.d"
+SetupDir="/usr/local/wlinux-setup.d"
 
 function ProcessArguments {
     while [[ $# -gt 0 ]]

--- a/wlinux-setup.d/docker.sh
+++ b/wlinux-setup.d/docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 DOCKERVERSION="18.09.0"
 DOCKERCOMPOSEVERSION="1.23.1"

--- a/wlinux-setup.d/dotnet.sh
+++ b/wlinux-setup.d/dotnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "DOTNET" --yesno "Would you like to download and install the .NET Core SDK for Linux?" 8 75) then
     echo "Installing DOTNET"

--- a/wlinux-setup.d/editors.sh
+++ b/wlinux-setup.d/editors.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 function neoviminstall {
 if (whiptail --title "NEOVIM" --yesno "Would you like to download and install neovim?" 8 50) then

--- a/wlinux-setup.d/explorer.sh
+++ b/wlinux-setup.d/explorer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explorer shell integration?" 8 65); then
     echo "Enabling Windows Explorer shell integration."

--- a/wlinux-setup.d/fzf.sh
+++ b/wlinux-setup.d/fzf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "FZF" --yesno "Would you like to download and install command line finder fzf?" 8 80) then
     echo "Installing FZF"

--- a/wlinux-setup.d/go.sh
+++ b/wlinux-setup.d/go.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 GOVERSION="1.11.4"
 

--- a/wlinux-setup.d/gui.sh
+++ b/wlinux-setup.d/gui.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 whiptail --title "Note about GUI Apps" --msgbox "Use of GUI applications on WLinux requires an X server running on Windows 10.\n\nExamples include:\n\nX410\nVcXsrv\nXming" 15 60
 

--- a/wlinux-setup.d/java.sh
+++ b/wlinux-setup.d/java.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "OpenJDK" --yesno "Would you like to Install OpenJDK 8?" 8 42) then
     echo "$ apt install openjdk-8-jre openjdk-8-jdk -y"

--- a/wlinux-setup.d/language.sh
+++ b/wlinux-setup.d/language.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "Language" --yesno "Would you like to configure default keyboard input/language?" 8 65) then
     echo "Running $ dpkg-reconfigure locales"

--- a/wlinux-setup.d/powershell.sh
+++ b/wlinux-setup.d/powershell.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "OpenJDK" --yesno "Would you like to Install OpenJDK 8?" 8 42) then
     echo "$ apt install openjdk-8-jre openjdk-8-jdk -y"

--- a/wlinux-setup.d/pythonpi.sh
+++ b/wlinux-setup.d/pythonpi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "PYTHON" --yesno "Would you like to download and install Python 3.7, IDLE, and the pip package manager?" 8 90) then
     echo "Installing PYTHON"

--- a/wlinux-setup.d/rust.sh
+++ b/wlinux-setup.d/rust.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 if (whiptail --title "RUST" --yesno "Would you like to download and install the latest version of Rust via rustup?" 8 85) then
     echo "Installing rust"

--- a/wlinux-setup.d/shells.sh
+++ b/wlinux-setup.d/shells.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/etc/wlinux-setup.d/common.sh"
+source "/usr/local/wlinux-setup.d/common.sh"
 
 function zshinstall {
 ZSH_SETUP=".zsh_wlinux"


### PR DESCRIPTION
Move the wlinux-setup.d install location from /usr/local/bin
to /usr/local. /usr/local/bin only contains executables so
the scripts folder installing here may not adhere to Linux
filesystem etiquette. Main wlinux-setup script will still
be installed to /usr/local/bin, only referenced scripts moved.

Signed-off-by: Kim Bradley <kim.jamie.bradley@gmail.com>