### PR TITLE
Add dh_usrlocal build step override to fix package-build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,3 +23,8 @@
 #override_dh_auto_configure:
 #	dh_auto_configure -- #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
+override_dh_usrlocal:
+    # Skip when building our package.
+    # /usr/local by debian policy kept for system adminstrator packages
+    # however as this is our own distribution and they are required /
+    # administrative packages we can allow them to be installed here


### PR DESCRIPTION
As explained in this StackOverflow thread: https://stackoverflow.com/questions/7459644/why-is-dh-usrlocal-throwing-a-build-error
_"The purpose is to aid with policy compliance by that package. According to Debian policy (and, IIRC, the Filesystem Hierarchy Standard or FHS), official Debian packages are not permitted to own files or directories under /usr/local - that directory tree belongs to the local system administrator."_

However, as this is our own distribution, and these files are system/administrative in function for our own distribution, we can safely override the dh_usrlocal policy check for both wlinux-base and wlinux-setup.

Signed-off-by: Kim Bradley <kim.jamie.bradley@gmail.com>