### PR TITLE
Further fixes for 1.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,5 @@ Vcs-Git: https://github.com/WhitewaterFoundry/wlinux-setup.git
 
 Package: wlinux-setup
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, git
 Description: Setup tool for WLinux.

--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -43,4 +43,11 @@ echo "Removing unnecessary packages: $ sudo apt autoremove -y"
 sudo apt autoremove -y
 }
 
+function getexec {
+user_path=$(cmd.exe /c "echo %HOMEDRIVE%%HOMEPATH%" 2>&1 | tr -d "\r")
+wslexec_dir=$(echo $PATH | sed -e 's/:/\n/g' | grep 'Program\ Files/WindowsApps')
+execname=$(ls "${wslexec_dir}" | grep '.exe')
+echo "${execname}"
+}
+
 ProcessArguments "$@"

--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -39,6 +39,14 @@ echo "Updating apt package index from repositories: $ sudo apt update"
 sudo apt update
 echo "Applying available package upgrades from repositories: $ sudo apt upgrade -y"
 sudo apt upgrade -y
+
+echo "Installing necessary prerequisites..."
+PKG_OK=$(dpkg-query -W --showformat='${Status}\n' git | grep "install ok installed")
+if [ "" == "$PKG_OK" ]; then
+  echo "Git not installed. Installing"
+  sudo apt-get --force-yes --yes install git
+fi
+
 echo "Removing unnecessary packages: $ sudo apt autoremove -y"
 sudo apt autoremove -y
 }

--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -39,14 +39,6 @@ echo "Updating apt package index from repositories: $ sudo apt update"
 sudo apt update
 echo "Applying available package upgrades from repositories: $ sudo apt upgrade -y"
 sudo apt upgrade -y
-
-echo "Installing necessary prerequisites..."
-PKG_OK=$(dpkg-query -W --showformat='${Status}\n' git | grep "install ok installed")
-if [ "" == "$PKG_OK" ]; then
-  echo "Git not installed. Installing"
-  sudo apt-get --force-yes --yes install git
-fi
-
 echo "Removing unnecessary packages: $ sudo apt autoremove -y"
 sudo apt autoremove -y
 }

--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -43,7 +43,7 @@ echo "Removing unnecessary packages: $ sudo apt autoremove -y"
 sudo apt autoremove -y
 }
 
-function getexec {
+function getexecname {
 user_path=$(cmd.exe /c "echo %HOMEDRIVE%%HOMEPATH%" 2>&1 | tr -d "\r")
 wslexec_dir=$(echo $PATH | sed -e 's/:/\n/g' | grep 'Program\ Files/WindowsApps')
 execname=$(ls "${wslexec_dir}" | grep '.exe')

--- a/wlinux-setup.d/dotnet.sh
+++ b/wlinux-setup.d/dotnet.sh
@@ -10,7 +10,7 @@ if (whiptail --title "DOTNET" --yesno "Would you like to download and install th
     rm microsoft.gpg
     sudo sh -c 'echo "deb https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list' 
     updateupgrade
-    sudo apt install dotnet-sdk-2.1 -y
+    sudo apt install dotnet-sdk-2.1.300-rc1* -y
     cleantmp
 
     if (whiptail --title "NUGET" --yesno "Would you like to download and install NuGet?" 8 50) then

--- a/wlinux-setup.d/explorer.sh
+++ b/wlinux-setup.d/explorer.sh
@@ -2,32 +2,37 @@
 
 source $(dirname "$0")/common.sh "$@"
 
+execname=$(getexecname)
+echo "WSL executable name: ${execname}"
+plainname=$(echo ${execname} | cut -s -d'.' -f1)
+
 if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explorer shell integration?" 8 65); then
     echo "Enabling Windows Explorer shell integration."
     createtmp
-    cat << 'EOF' >> Install.reg
+    cat << EOF >> Install.reg
     Windows Registry Editor Version 5.00
-    [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\WLinux]
-    @="Open with WLinux"
-    [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\WLinux\command]
-    @="_wlinuxPath_ run \"cd \\\"$(wslpath \\\"%V\\\")\\\" && $(getent passwd $LOGNAME | cut -d: -f7)\""
-    [HKEY_CURRENT_USER\Software\Classes\Directory\shell\WLinux]
-    @="Open with WLinux"
-    [HKEY_CURRENT_USER\Software\Classes\Directory\shell\WLinux\command]
-    @="_wlinuxPath_ run \"cd \\\"$(wslpath \\\"%V\\\")\\\" && $(getent passwd $LOGNAME | cut -d: -f7)\""
+    [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\\${plainname}]
+    @="Open with ${plainname}"
+    [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\\${plainname}\command]
+    @="_${plainname}Path_ run \\"cd \\\\\\"\$(wslpath \\\\\\"%V\\\\\\")\\\\\\" && \$(getent passwd \$LOGNAME | cut -d: -f7)\\""
+    [HKEY_CURRENT_USER\Software\Classes\Directory\shell\\${plainname}]
+    @="Open with ${plainname}"
+    [HKEY_CURRENT_USER\Software\Classes\Directory\shell\\${plainname}\command]
+    @="_${plainname}Path_ run \\"cd \\\\\\"\$(wslpath \\\\\\"%V\\\\\\")\\\\\\" && \$(getent passwd \$LOGNAME | cut -d: -f7)\\""
 EOF
-    wlinuxPath=$(wslpath -m "$(whereis wlinux.exe | cut --delimiter=' ' -f2)" | sed 's$/$\\\\\\\\$g')
-    sed -i "s/_wlinuxPath_/${wlinuxPath}/g" Install.reg
+
+    execpath=$(wslpath -m "$(whereis ${execname} | cut --delimiter=' ' -f2)" | sed 's$/$\\\\\\\\$g')
+    sed -i "s/_${plainname}Path_/${execpath}/g" Install.reg
     cp Install.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Install.reg
     cmd.exe /C "Reg import %TEMP%\Install.reg"
     cleantmp
  else
     echo "Disabling Windows Explorer shell integration."
     createtmp
-    cat << 'EOF' >> Uninstall.reg
+    cat << EOF >> Uninstall.reg
     Windows Registry Editor Version 5.00
-    [-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\WLinux]
-    [-HKEY_CURRENT_USER\Software\Classes\Directory\shell\WLinux]
+    [-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\\${plainname}]
+    [-HKEY_CURRENT_USER\Software\Classes\Directory\shell\\${plainname}]
 EOF
     cp Uninstall.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Uninstall.reg
     cmd.exe /C "Reg import %TEMP%\Uninstall.reg"


### PR DESCRIPTION
- added code to wlinux-setup.d/common.sh to get the WSL distro executable name, so the explorer integration installer can be independent of installed distribution
- add git dependency to wlinux-setup (ensures git is installed before running wlinux-setup on all distros)
- update installed package in dotnet.sh, only latest preview package is able to install without dependency issues