### PR TITLE
Explorer integration fix

### DIFF
--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -50,4 +50,16 @@ execname=$(ls "${wslexec_dir}" | grep '.exe')
 echo "${execname}"
 }
 
+function getexecpath {
+n=1
+while [ $n -lt 25 ] ; do
+    pathitem="$(echo $PATH | cut -d':' -f$n)"
+    if echo $pathitem | grep 'Program Files/WindowsApps' ; then
+        echo $pathitem
+	return
+    fi
+    n=$((n+1))
+done
+}
+
 ProcessArguments "$@"

--- a/wlinux-setup.d/common.sh
+++ b/wlinux-setup.d/common.sh
@@ -54,10 +54,7 @@ function getexecpath {
 n=1
 while [ $n -lt 25 ] ; do
     pathitem="$(echo $PATH | cut -d':' -f$n)"
-    if echo $pathitem | grep 'Program Files/WindowsApps' ; then
-        echo $pathitem
-	return
-    fi
+    echo $pathitem | grep 'Program Files/WindowsApps'
     n=$((n+1))
 done
 }

--- a/wlinux-setup.d/explorer.sh
+++ b/wlinux-setup.d/explorer.sh
@@ -21,8 +21,9 @@ if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explor
     @="_${plainname}Path_ run \\"cd \\\\\\"\$(wslpath \\\\\\"%V\\\\\\")\\\\\\" && \$(getent passwd \$LOGNAME | cut -d: -f7)\\""
 EOF
 
-execpath=$(wslpath -m $(getexecpath) | sed 's$/$\\\\\\\\$g')
-    sed -i "s/_${plainname}Path_/${execpath}/g" Install.reg
+    execpath=$(wslpath -m "$(getexecpath)" | sed 's$/$\\\\\\\\$g')
+    fullexec="${execpath}\\\\\\\\${execname}"
+    sed -i "s/_${plainname}Path_/${fullexec}/g" Install.reg
     cp Install.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Install.reg
     cmd.exe /C "Reg import %TEMP%\Install.reg"
     cleantmp

--- a/wlinux-setup.d/explorer.sh
+++ b/wlinux-setup.d/explorer.sh
@@ -21,7 +21,7 @@ if (whiptail --title "EXPLORER" --yesno "Would you like to enable Windows Explor
     @="_${plainname}Path_ run \\"cd \\\\\\"\$(wslpath \\\\\\"%V\\\\\\")\\\\\\" && \$(getent passwd \$LOGNAME | cut -d: -f7)\\""
 EOF
 
-    execpath=$(wslpath -m "$(whereis ${execname} | cut --delimiter=' ' -f2)" | sed 's$/$\\\\\\\\$g')
+execpath=$(wslpath -m $(getexecpath) | sed 's$/$\\\\\\\\$g')
     sed -i "s/_${plainname}Path_/${execpath}/g" Install.reg
     cp Install.reg $(wslpath "$(cmd.exe /c 'echo %TEMP%' 2>&1 | tr -d '\r')")/Install.reg
     cmd.exe /C "Reg import %TEMP%\Install.reg"


### PR DESCRIPTION
Managed to fix my distribution agnostic implementation of explorer integration. It places 2 new functions in common.sh -- getexecname and getexecpath. These are then used to fill in the variables in explorer.sh, though the implementation of EOF had to be modified to actually format text instead of just copy char-for-char, which leads to /a lot/ of extra backslashes :stuck_out_tongue:

See screenshot:
![screen](https://user-images.githubusercontent.com/29276828/53402618-fbe73280-39a9-11e9-942f-ded30f137e70.png)

Going to do some more testing and merge in if no issues found.