### PR TITLE
Refinements for go.sh

### DIFF
--- a/wlinux-setup.d/go.sh
+++ b/wlinux-setup.d/go.sh
@@ -2,7 +2,7 @@
 
 source $(dirname "$0")/common.sh "$@"
 
-GOVERSION="1.11.4"
+GOVERSION="1.12"
 
 if (whiptail --title "GO" --yesno "Would you like to download and install the latest Go from Google?" 8 70) then
     createtmp
@@ -17,9 +17,10 @@ if (whiptail --title "GO" --yesno "Would you like to download and install the la
     export GOPATH=$HOME/go/
     export PATH=$GOPATH/bin:$GOROOT/bin:/usr/local/go/bin:$PATH
     echo "Saving Go environment variables to /etc/profile so they will persist."
-    sudo sh -c 'echo "export GOROOT=/usr/local/go" >> /etc/profile'
-    sudo sh -c 'echo "export GOPATH=\${HOME}/go/" >> /etc/profile'
-    sudo sh -c 'echo "export PATH=\${GOPATH}/bin:\${GOROOT}/bin:/usr/local/go/bin:\${PATH}" >> /etc/profile'
+    sudo sh -c 'echo "export GOROOT=/usr/local/go" >> /etc/profile.d/go.sh'
+    sudo sh -c 'echo "export GOPATH=\${HOME}/go/" >> /etc/profile.d/go.sh'
+    sudo sh -c 'echo "export PATH=\${GOPATH}/bin:\${GOROOT}/bin:/usr/local/go/bin:\${PATH}" >> /etc/profile.d/go.sh'
+    source /etc/profile.d/go.sh
     cleantmp
 else
     echo "Skipping GO"


### PR DESCRIPTION
This moves the go shell envs to their own script in profile.

It sources them after installation so go will work without restarting the app.

Finally it updates go to the latest version.