### PR TITLE
Add wslu dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,5 @@ Vcs-Git: https://github.com/WhitewaterFoundry/wlinux-setup.git
 
 Package: wlinux-setup
 Architecture: all
-Depends: ${misc:Depends}, git
+Depends: ${misc:Depends}, git, wslu
 Description: Setup tool for WLinux.


### PR DESCRIPTION
Adds wslu dependency to wlinux-setup to make sure wslu is pulled into installs from the newly added packagecloud repository.