### PR TITLE
Add essential flag to wlinux-setup package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,3 +12,4 @@ Package: wlinux-setup
 Architecture: all
 Depends: ${misc:Depends}, git, wslu
 Description: Setup tool for WLinux.
+Essential: yes


### PR DESCRIPTION
Marks package as essential such that the user is asked `You are about to do something potentially harmful. To continue type in the phrase 'Yes, do as I say!'`.

Have ran tests on my own build and all seems to work fine, and works the same as any other essential package e.g. bash