### PR TITLE
Fix doctl completion filename

### DIFF
--- a/pengwin-setup.d/cloudcli.sh
+++ b/pengwin-setup.d/cloudcli.sh
@@ -122,7 +122,7 @@ function install_doctl() {
     sudo mkdir -p /etc/bash_completion.d
     sudo apt-get install -yq bash-completion
 
-    doctl completion bash | sudo tee /etc/bash_completion.d/doc.bash_completion >/dev/null
+    doctl completion bash | sudo tee /etc/bash_completion.d/doctl.bash_completion >/dev/null
     doctl version
 
     cleantmp

--- a/pengwin-setup.d/uninstall/doctl.sh
+++ b/pengwin-setup.d/uninstall/doctl.sh
@@ -10,7 +10,7 @@ function main() {
   sudo_rem_file "/usr/local/bin/doctl"
 
   echo "Removing bash completion..."
-  sudo_rem_file "/etc/bash_completion.d/doc.bash_completion"
+  sudo_rem_file "/etc/bash_completion.d/doctl.bash_completion"
 
 }
 

--- a/rpm/pengwin-setup.d/cloudcli.sh
+++ b/rpm/pengwin-setup.d/cloudcli.sh
@@ -120,7 +120,7 @@ function install_doctl() {
     sudo mkdir -p /etc/bash_completion.d
     sudo apt-get install -yq bash-completion
 
-    doctl completion bash | sudo tee /etc/bash_completion.d/doc.bash_completion >/dev/null
+    doctl completion bash | sudo tee /etc/bash_completion.d/doctl.bash_completion >/dev/null
     doctl version
 
     cleantmp

--- a/rpm/pengwin-setup.d/uninstall/doctl.sh
+++ b/rpm/pengwin-setup.d/uninstall/doctl.sh
@@ -10,7 +10,7 @@ function main() {
   sudo_rem_file "/usr/local/bin/doctl"
 
   echo "Removing bash completion..."
-  sudo_rem_file "/etc/bash_completion.d/doc.bash_completion"
+  sudo_rem_file "/etc/bash_completion.d/doctl.bash_completion"
 
 }
 


### PR DESCRIPTION
## Summary
- fix DigitalOcean CLI completion file name

## Testing
- `bash tests/run_tests.sh` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684067c6deb083279e8e00bebfbc1e7a