### PR TITLE
Add Microsoft Edit installer

### DIFF
--- a/pengwin-setup
+++ b/pengwin-setup
@@ -249,7 +249,7 @@ Commands:
   startmenu                      Regenerate the start menu icons. Implies --noupdate, --noninteractive, and --yes.
 
 Actions to be used after install command:
-  EDITORS                        Available editors: CODE, EMACS, NEOVIM.
+  EDITORS                        Available editors: CODE, EMACS, NEOVIM, MSEDIT.
 
   GUI                            GUI-related options: CONFIGURE, DESKTOP, NLI, GUILIB, HIDPI, TERMINAL, SYNAPTIC, WINTHEME, WSLG.
 

--- a/pengwin-setup.d/editors.sh
+++ b/pengwin-setup.d/editors.sh
@@ -71,6 +71,7 @@ function editor_menu() {
 
     menu --title "Editor Menu" --menu "Custom editors (nano and vi included)\n[ENTER to confirm]:" 14 70 3 \
       "CODE" "Visual Studio Code Linux version${REQUIRES_X}   " \
+      "MSEDIT" "Microsoft Edit CLI" \
       "EMACS" "Emacs" \
       "NEOVIM" "Neovim"
 
@@ -92,6 +93,13 @@ function editor_menu() {
 
   if [[ ${editor_choice} == *"CODE"* ]]; then
     code_install
+  fi
+
+  if [[ ${editor_choice} == *"MSEDIT"* ]]; then
+    bash "${SetupDir}"/microsoft-edit.sh "$@"
+    if [[ -f /usr/local/bin/edit ]]; then
+      INSTALLED=true
+    fi
   fi
 
   if [[ "${INSTALLED}" == true ]]; then

--- a/pengwin-setup.d/microsoft-edit.sh
+++ b/pengwin-setup.d/microsoft-edit.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# shellcheck source=./common.sh
+source "$(dirname "$0")/common.sh" "$@"
+
+readonly EDIT_GITHUB_API_URL="https://api.github.com/repos/microsoft/edit/releases/latest"
+readonly EDIT_INSTALL_DEST="/usr/local/bin/edit"
+
+function msedit_install() {
+  if (confirm --title "MICROSOFT EDIT" --yesno "Would you like to download and install Microsoft Edit CLI?" 8 70); then
+    echo "Installing Microsoft Edit"
+    install_packages curl jq tar zstd
+
+    createtmp
+
+    local arch
+    case "$(dpkg --print-architecture)" in
+      amd64) arch="x86_64" ;;
+      arm64) arch="aarch64" ;;
+      *) echo "Unsupported architecture"; cleantmp; return 1 ;;
+    esac
+
+    echo "Fetching latest release information"
+    local asset_url
+    asset_url=$(curl -sSL "${EDIT_GITHUB_API_URL}" | \
+      jq -r --arg arch "$arch" '.assets[] | select(.name | test("^edit-.*-" + $arch + "-linux-gnu\\.tar\\.zst$")) | .browser_download_url' | head -n 1)
+
+    if [[ -z "${asset_url}" ]]; then
+      echo "No suitable asset found for ${arch}"
+      cleantmp
+      return 1
+    fi
+
+    echo "Downloading asset"
+    curl -L "${asset_url}" -o edit.tar.zst
+
+    echo "Extracting archive"
+    unzstd -c edit.tar.zst | tar -xf -
+
+    local edit_path
+    edit_path=$(find . -type f -name edit -perm -111 | head -n 1)
+    if [[ -z "${edit_path}" ]]; then
+      echo "edit binary not found inside archive."
+      cleantmp
+      return 1
+    fi
+
+    echo "Installing to ${EDIT_INSTALL_DEST}"
+    sudo install -Dm755 "${edit_path}" "${EDIT_INSTALL_DEST}"
+
+    echo "Registering with update-alternatives"
+    sudo update-alternatives --install /usr/bin/editor editor "${EDIT_INSTALL_DEST}" 30
+
+    cleantmp
+    INSTALLED=true
+  else
+    echo "Skipping Microsoft Edit"
+  fi
+}
+
+msedit_install "$@"

--- a/pengwin-setup.d/uninstall/microsoft-edit.sh
+++ b/pengwin-setup.d/uninstall/microsoft-edit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# shellcheck source=./uninstall-common.sh
+source "$(dirname "$0")/uninstall-common.sh" "$@"
+
+function main() {
+  echo "Uninstalling Microsoft Edit"
+  sudo_rem_file "/usr/local/bin/edit"
+  sudo update-alternatives --remove editor /usr/local/bin/edit || true
+}
+
+if show_warning "Microsoft Edit" "$@"; then
+  main "$@"
+fi

--- a/tests/microsoft_edit.sh
+++ b/tests/microsoft_edit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source commons.sh
+
+function test_main() {
+  run_pengwinsetup autoinstall EDITORS MSEDIT
+
+  assertTrue "Microsoft Edit binary missing" "[ -f /usr/local/bin/edit ]"
+  command -v /usr/local/bin/edit
+  assertEquals "Microsoft Edit was not installed" "0" "$?"
+  assertEquals "update-alternatives not configured" "1" "$(run update-alternatives --list editor | grep -c '/usr/local/bin/edit')"
+}
+
+function test_uninstall() {
+  run_pengwinsetup autoinstall UNINSTALL MSEDIT
+
+  assertFalse "Microsoft Edit binary still present" "[ -f /usr/local/bin/edit ]"
+  assertEquals "update-alternatives entry still present" "0" "$(run update-alternatives --list editor | grep -c '/usr/local/bin/edit')"
+}
+
+# shellcheck disable=SC1091
+source shunit2

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,6 +22,7 @@ if [ -z "${CIRCLE_NODE_TOTAL}" ]; then
   run_test ./hidpi.sh
   run_test ./dotnet.sh
   run_test ./brew.sh
+  run_test ./microsoft_edit.sh
   #run_test ./guilib.sh
   run_test ./desktop.sh
   run_test ./terraform.sh
@@ -54,6 +55,7 @@ elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #5
 elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #6
   #run_test ./lamp.sh "10.9"
   run_test ./brew.sh
+  run_test ./microsoft_edit.sh
   run_test ./nodejs_latest.sh
 elif [[ ${CIRCLE_NODE_INDEX} == $((i++)) ]]; then #7
   run_test ./pythonpi.sh


### PR DESCRIPTION
## Summary
- add Microsoft Edit installer script and uninstaller
- register Microsoft Edit in the editors menu
- document Microsoft Edit availability in help text
- add regression tests for Microsoft Edit

## Testing
- `./run_tests.sh` *(fails: shunit2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840712c51b08327a0afc13ff4ef24b4