### PR TITLE
Update Microsoft repositories to Bookworm and upgrade .NET SDK to 9.0

### DIFF
--- a/pengwin-setup.d/azurecli.sh
+++ b/pengwin-setup.d/azurecli.sh
@@ -11,14 +11,10 @@ if (confirm --title "AZURECLI" --yesno "Would you like to download and install A
 
   sudo chmod 644 /etc/apt/trusted.gpg.d/microsoft.gpg
 
-  sudo bash -c "echo 'deb https://packages.microsoft.com/repos/azure-cli/ bullseye main' > /etc/apt/sources.list.d/azurecli.list"
+  sudo bash -c "echo 'deb https://packages.microsoft.com/repos/azure-cli/ bookworm main' > /etc/apt/sources.list.d/azurecli.list"
 
-  sudo apt-get -y -q update
-  install_packages -t bullseye azure-cli
-
-  # Remove wslview as the default browser
-  wslview -u
-
+  update_packages
+  install_packages -t bookworm azure-cli
 else
   echo "Skipping AZURECLI"
 fi

--- a/pengwin-setup.d/dotnet.sh
+++ b/pengwin-setup.d/dotnet.sh
@@ -20,11 +20,11 @@ if (confirm --title "DOTNET" --yesno "Would you like to download and install the
   curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
   sudo cp microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 
-  echo 'deb https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main' | sudo tee /etc/apt/sources.list.d/microsoft.list
+  echo 'deb https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main' | sudo tee /etc/apt/sources.list.d/microsoft.list
 
   update_packages
 
-  install_packages dotnet-sdk-7.0
+  install_packages dotnet-sdk-9.0
   cleantmp
 
   if (confirm --title "NUGET" --yesno "Would you like to download and install NuGet?" 8 50) ; then

--- a/pengwin-setup.d/powershell.sh
+++ b/pengwin-setup.d/powershell.sh
@@ -11,7 +11,7 @@ if (confirm --title "POWERSHELL" --yesno "Would you like to download and install
   curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >microsoft.gpg
   sudo cp microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 
-  sudo sh -c 'echo "deb https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
+  sudo sh -c 'echo "deb https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main" > /etc/apt/sources.list.d/microsoft.list'
 
   update_packages
   install_packages powershell

--- a/pengwin-setup.d/uninstall/dotnet.sh
+++ b/pengwin-setup.d/uninstall/dotnet.sh
@@ -7,7 +7,7 @@ function main() {
 
   echo "Uninstalling dotnet"
 
-  remove_package "dotnet-sdk-3.1" "dotnet-sdk-5.0" "dotnet-sdk-6.0" "dotnet-sdk-7.0" "nuget"
+  remove_package "dotnet-sdk-3.1" "dotnet-sdk-5.0" "dotnet-sdk-6.0" "dotnet-sdk-7.0" "dotnet-sdk-9.0" "nuget"
 
   echo "Removing leftover dotnet cli tools directory..."
   rem_dir "$HOME/.dotnet"

--- a/tests/dotnet.sh
+++ b/tests/dotnet.sh
@@ -11,12 +11,12 @@ function testMain() {
 
   run_pengwinsetup autoinstall PROGRAMMING DOTNET
 
-  for i in 'dotnet-sdk-7.0' 'nuget'; do
+  for i in 'dotnet-sdk-9.0' 'nuget'; do
     package_installed $i
     assertTrue "package $i is not installed" "$?"
   done
 
-  assertEquals ".NET Core was not installed" "1" "$(run /usr/bin/dotnet --version | grep -c '7.0')"
+  assertEquals ".NET Core was not installed" "1" "$(run /usr/bin/dotnet --version | grep -c '9.0')"
 
   command -v /usr/bin/nuget
   assertEquals "NUGet was not installed" "0" "$?"
@@ -31,7 +31,7 @@ function testUninstall() {
 
   run_pengwinsetup autoinstall UNINSTALL DOTNET
 
-  for i in 'dotnet-sdk-7.0' 'nuget'; do
+  for i in 'dotnet-sdk-9.0' 'nuget'; do
     package_installed $i
     assertFalse "package $i is not uninstalled" "$?"
   done


### PR DESCRIPTION
This pull request updates the installation scripts and tests to support Debian Bookworm and the latest versions of key Microsoft packages. The most significant changes include migrating package sources from Bullseye to Bookworm, upgrading the default .NET SDK version from 7.0 to 9.0, and updating related uninstall scripts and tests for consistency.

**Distribution migration:**
* Updated package sources in `azurecli.sh`, `dotnet.sh`, and `powershell.sh` to use Debian Bookworm repositories instead of Bullseye, ensuring compatibility with newer distributions. [[1]](diffhunk://#diff-8c3020ddb9f9da5c7f89d444425d6a478a926b768b38af3399532f5fcef001afL14-R17) [[2]](diffhunk://#diff-15a45be56116e7973e16fd2109493ef317cc576a89964bf58d7093eeb81279f9L23-R27) [[3]](diffhunk://#diff-e9dc7fda31a582cfd5a5e37f21651df6e62885604927dba61fa041c1d94ac1e9L14-R14)

**.NET SDK version upgrade:**
* Changed the default installed .NET SDK version from `dotnet-sdk-7.0` to `dotnet-sdk-9.0` in `dotnet.sh`, and updated uninstall logic in `uninstall/dotnet.sh` to remove `dotnet-sdk-9.0` as well. [[1]](diffhunk://#diff-15a45be56116e7973e16fd2109493ef317cc576a89964bf58d7093eeb81279f9L23-R27) [[2]](diffhunk://#diff-3f2febaddb1bdf01936d186c800a439404ba7f86da81e3d51c940f71bd3161c7L10-R10)

**Test updates:**
* Modified tests in `tests/dotnet.sh` to check for installation and uninstallation of `dotnet-sdk-9.0` instead of `dotnet-sdk-7.0`, and updated version assertions accordingly. [[1]](diffhunk://#diff-05ee6b5fbbdc9b18c0366ceeb0468d6ab30e74cd69284769934b2d2267cf9770L14-R19) [[2]](diffhunk://#diff-05ee6b5fbbdc9b18c0366ceeb0468d6ab30e74cd69284769934b2d2267cf9770L34-R34)